### PR TITLE
O3-5519: Add BOT_GH_TOKEN to build workflow secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,3 +17,4 @@ jobs:
       NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
       MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
+      BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,3 @@ jobs:
       MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
       MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
       BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}
- 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,4 @@ jobs:
       MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
       MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
       BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}
+ 


### PR DESCRIPTION
## Description
Ticket Link - https://openmrs.atlassian.net/browse/O3-5519
Ticket ID - O3-5519

## Summary
The shared OWASP Dependency Check workflow (openmrs-contrib-gha-workflows) has been updated to automatically push generated vulnerability reports to the central dashboard repository (openmrs-contrib-dependency-vulnerability-dashboard). To support this, the reusable workflow now requires the GH_BOT_TOKEN secret to be passed by calling repositories. Without it, the workflow cannot push reports to the dashboard.

## Change
Added `BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}` to the secrets block in `.github/workflows/build.yml`.